### PR TITLE
Update Packet.cs

### DIFF
--- a/LeagueSharp.Common/LeagueSharp.Common/Packet.cs
+++ b/LeagueSharp.Common/LeagueSharp.Common/Packet.cs
@@ -33,8 +33,9 @@ namespace LeagueSharp.Common
     {
         public enum DamageTypePacket
         {
-            Magical = 4,
-            Physical = 12,
+            Spell = 4,
+            CriticalAttack = 11,
+            Attack = 12,
             True = 36,
         }
 


### PR DESCRIPTION
I receive damagetype 4 for all spells regardless of physical/magical, which indicates to me that 4 = any spell damage, not specifically magic damage.
I've never received damagetype 12 for a non-basic attack.
Damagetype 11 is critical attack
