### PR TITLE
Update Packet.PingType.Normal

### DIFF
--- a/LeagueSharp.Common/LeagueSharp.Common/Packet.cs
+++ b/LeagueSharp.Common/LeagueSharp.Common/Packet.cs
@@ -141,7 +141,7 @@ namespace LeagueSharp.Common
 
         public enum PingType
         {
-            Normal = 1,
+            Normal = 0,
             Fallback = 5,
             EnemyMissing = 3,
             Danger = 2,


### PR DESCRIPTION
Printing out `Packet.S2C.Ping.Decoded(args.PacketData).Type` shows 0 for normal ping
