### PR TITLE
Fix Utility.GetRecallTime & Recall Packet (new summoners rift)

### DIFF
--- a/LeagueSharp.Common/LeagueSharp.Common/Utility.cs
+++ b/LeagueSharp.Common/LeagueSharp.Common/Utility.cs
@@ -151,42 +151,25 @@ namespace LeagueSharp.Common
 
         public static int GetRecallTime(Obj_AI_Hero obj)
         {
-            var duration = 0;
-
-            switch (obj.Spellbook.GetSpell(SpellSlot.Recall).Name)
-            {
-                case "Recall":
-                    duration = 8000;
-                    break;
-                case "RecallImproved":
-                    duration = 7000;
-                    break;
-                case "OdinRecall":
-                    duration = 4500;
-                    break;
-                case "OdinRecallImproved":
-                    duration = 4000;
-                    break;
-            }
-            return duration;
+            return GetRecallTime(obj.Spellbook.GetSpell(SpellSlot.Recall).Name);
         }
 
         public static int GetRecallTime(string recallName)
         {
             var duration = 0;
 
-            switch (recallName)
+            switch (recallName.ToLower())
             {
-                case "Recall":
+                case "recall":
                     duration = 8000;
                     break;
-                case "RecallImproved":
+                case "recallimproved":
                     duration = 7000;
                     break;
-                case "OdinRecall":
+                case "odinrecall":
                     duration = 4500;
                     break;
-                case "OdinRecallImproved":
+                case "odinrecallimproved":
                     duration = 4000;
                     break;
             }


### PR DESCRIPTION
The name of the Recall spell is called "recall" on the new map. So no capitals unlike the Dominion map. This also fixes the RecallStatus of the Recall packet on the new map.
