### PR TITLE
Added baron recall + fix when spelldata is unknown

### DIFF
--- a/LeagueSharp.Common/LeagueSharp.Common/Packet.cs
+++ b/LeagueSharp.Common/LeagueSharp.Common/Packet.cs
@@ -1908,7 +1908,7 @@ namespace LeagueSharp.Common
                         }
 
                         result.Type = ObjectType.Player;
-                        var duration = Utility.GetRecallTime(unit);
+                        var duration = Utility.GetRecallTime(packet.ReadString(139));
 
                         result.Duration = duration;
 

--- a/LeagueSharp.Common/LeagueSharp.Common/Utility.cs
+++ b/LeagueSharp.Common/LeagueSharp.Common/Utility.cs
@@ -172,6 +172,9 @@ namespace LeagueSharp.Common
                 case "odinrecallimproved":
                     duration = 4000;
                     break;
+                case "superrecall":
+                    duration = 4000;
+                    break;
             }
             return duration;
         }


### PR DESCRIPTION
Spelldata is unknown when the player has never been seen in the game and tries to recall. The type of recall is sent with the packet as a string.
