### PR TITLE
Added new baron recalls + fix recall packet when spelldata is unknown

### DIFF
--- a/LeagueSharp.Common/LeagueSharp.Common/Packet.cs
+++ b/LeagueSharp.Common/LeagueSharp.Common/Packet.cs
@@ -1872,8 +1872,14 @@ namespace LeagueSharp.Common
                     TeleportEnd,
                 }
 
+                public struct RecallData
+                {
+                    public int Start { get; set; }
+                    public int Duration { get; set; }
+                }
+
                 public static byte Header = 0xD8;
-                public static readonly Dictionary<int, int> RecallT = new Dictionary<int, int>();
+                public static readonly Dictionary<int, RecallData> RecallT = new Dictionary<int, RecallData>();
                 public static readonly Dictionary<int, int> TPT = new Dictionary<int, int>();
 
                 public static GamePacket Encoded(Struct packetStruct)
@@ -1914,7 +1920,7 @@ namespace LeagueSharp.Common
 
                         if (!RecallT.ContainsKey(result.UnitNetworkId))
                         {
-                            RecallT.Add(result.UnitNetworkId, 0);
+                            RecallT.Add(result.UnitNetworkId, new RecallData());
                         }
 
                         if (!TPT.ContainsKey(result.UnitNetworkId))
@@ -1930,15 +1936,15 @@ namespace LeagueSharp.Common
                         else if (type == "Recall")
                         {
                             result.Status = RecallStatus.RecallStarted;
-                            RecallT[result.UnitNetworkId] = Environment.TickCount;
+                            RecallT[result.UnitNetworkId] = new RecallData { Duration = duration, Start = Environment.TickCount };
                         }
                         else if (string.IsNullOrEmpty(type))
                         {
-                            if (Environment.TickCount - RecallT[result.UnitNetworkId] < duration - 200)
+                            if (Environment.TickCount - RecallT[result.UnitNetworkId].Start < RecallT[result.UnitNetworkId].Duration - 50)
                             {
                                 result.Status = RecallStatus.RecallAborted;
                             }
-                            else if (Environment.TickCount - RecallT[result.UnitNetworkId] < duration + 200)
+                            else if (Environment.TickCount - RecallT[result.UnitNetworkId].Start < RecallT[result.UnitNetworkId].Duration + 50)
                             {
                                 result.Status = RecallStatus.RecallFinished;
                             }

--- a/LeagueSharp.Common/LeagueSharp.Common/Utility.cs
+++ b/LeagueSharp.Common/LeagueSharp.Common/Utility.cs
@@ -175,6 +175,9 @@ namespace LeagueSharp.Common
                 case "superrecall":
                     duration = 4000;
                     break;
+                case "superrecallimproved":
+                    duration = 4000;
+                    break;
             }
             return duration;
         }


### PR DESCRIPTION
Added superrecall and superrecallimproved. Also the recall packet now uses the type of recall that is sent with the packet as a string. Before, it could happen that an enemy has never been seen and because of that his spelldata was unknown causing the recall packet to fail as well.

And yes, I've tested the new values of baron recall. Apparently riot didn't notice that the phasewalker mastery isn't brought into calculation with baron recall.
