### PR TITLE
Fixed Auto Priority Bug.

### DIFF
--- a/LeagueSharp.Common/LeagueSharp.Common/TargetSelector.cs
+++ b/LeagueSharp.Common/LeagueSharp.Common/TargetSelector.cs
@@ -528,9 +528,15 @@ namespace LeagueSharp.Common
             {
                 Config.AddItem(
                     new MenuItem("SimpleTS" + enemy.ChampionName + "Priority", enemy.ChampionName).SetShared()
-                        .SetValue(
+                        .SetValue<Slider>(
                             new Slider(
                                 autoPriorityItem.GetValue<bool>() ? GetPriorityFromDb(enemy.ChampionName) : 1, 5, 1)));
+                if(autoPriorityItem.GetValue<bool>())
+                {
+                    Config.Item("SimpleTS" + enemy.ChampionName + "Priority")
+                        .SetValue<Slider>(new Slider(
+                            autoPriorityItem.GetValue<bool>() ? GetPriorityFromDb(enemy.ChampionName) : 1, 5, 1));
+                }
             }
             Config.AddItem(autoPriorityItem);
             Config.AddItem(new MenuItem("TargetingMode", "Target Mode").SetShared().SetValue<StringList>(new StringList(new[] { "Low HP", "Most AD", "Most AP", "Closest", "Near Mouse", "Priority", "Less Attack", "Less Cast" }, 5)));


### PR DESCRIPTION
Reported @ http://www.joduska.me/forum/tracker/issue-123-simplets-doesnt-auto-arrange-priorities-on-startup/

Issue is that when creating a new item, it'll load old settings if it has them and won't apply new ones.
This little fix checks if "Auto Arrange priorites" is on after the creation and sets onto the menuitem once again.
