### PR TITLE
Fix Render.Sprite Height and Width

### DIFF
--- a/LeagueSharp.Common/LeagueSharp.Common/Render.cs
+++ b/LeagueSharp.Common/LeagueSharp.Common/Render.cs
@@ -878,12 +878,12 @@ namespace LeagueSharp.Common
 
             public int Width
             {
-                get { return Bitmap.Width; }
+                get { return (int) (Bitmap.Width * _scale.X); }
             }
 
             public int Height
             {
-                get { return Bitmap.Height; }
+                get { return (int) (Bitmap.Height * _scale.Y); }
             }
 
             public Vector2 Size


### PR DESCRIPTION
Scale wasn't used in calculation of width and height
