### PR TITLE
Fixed UpdateModel packet header

### DIFF
--- a/LeagueSharp.Common/LeagueSharp.Common/Packet.cs
+++ b/LeagueSharp.Common/LeagueSharp.Common/Packet.cs
@@ -1416,7 +1416,7 @@ namespace LeagueSharp.Common
             /// </summary>
             public static class UpdateModel
             {
-                public static byte Header = 0x1A;
+                public static byte Header = 0x17;
 
                 public static GamePacket Encoded(Struct packetStruct)
                 {


### PR DESCRIPTION
The 0x1A header gets received twice when a model update happens (Orianna for instance). The network ID's in 0x1A also don't match the player network ID whereas 0x17 gets received only once and the network ID's match up.