### PR TITLE
ChoGath R

### DIFF
--- a/Damage.cs
+++ b/Damage.cs
@@ -931,7 +931,7 @@ namespace LeagueSharp.Common
                         DamageType = DamageType.True,
                         Damage =
                             (source, target, level) =>
-                                new double[] { 300, 475, 650 }[level] + 0.7 * source.FlatMagicDamageMod
+                                target.Type == GameObjectType.obj_AI_Hero ? new double[] { 300, 475, 650 }[level] + 0.7 * source.FlatMagicDamageMod : 1000 + 0.7 * source.FlatMagicDamageMod
                     },
                 });
 


### PR DESCRIPTION
Add dmg calc for ChoGath R, attacking minion.

This time I tested :)

Sorry about kappa pull.

I made the change, and installed from my repository in l #, tested the calculations and is working, both for player and minion.

Added the ult in my activator, so I can use the calculation of the common, and will not involve problem for others, only improvement.

Thank you.