### PR TITLE
Some changes

### DIFF
--- a/Geometry.cs
+++ b/Geometry.cs
@@ -213,7 +213,17 @@ namespace LeagueSharp.Common
         {
             return v + distance * (to - v).Normalized();
         }
+        
+        public static Vector2 Shorten(this Vector2 v, Vector2 to, float distance)
+        {
+            return v - distance * (to - v).Normalized();
+        }
 
+        public static Vector3 Shorten(this Vector3 v, Vector3 to, float distance)
+        {
+            return v - distance * (to - v).Normalized();
+        }
+        
         public static Vector3 SwitchYZ(this Vector3 v)
         {
             return new Vector3(v.X, v.Z, v.Y);

--- a/Interrupter.cs
+++ b/Interrupter.cs
@@ -241,7 +241,17 @@ namespace LeagueSharp.Common
                     Slot = SpellSlot.W,
                     BuffName = "Drain",
                 });
-
+                //Max rank Drain had different buff name
+            Spells.Add(
+                new InterruptableSpell
+                {
+                    ChampionName = "FiddleSticks",
+                    SpellName = "Drain",
+                    DangerLevel = InterruptableDangerLevel.Medium,
+                    Slot = SpellSlot.W,
+                    BuffName = "fearmonger_marker",
+                });
+                /*  Crowstorm buffname only appears after finish casting.
             Spells.Add(
                 new InterruptableSpell
                 {
@@ -250,7 +260,7 @@ namespace LeagueSharp.Common
                     DangerLevel = InterruptableDangerLevel.High,
                     Slot = SpellSlot.R,
                     BuffName = "Crowstorm",
-                });
+                });*/
 
             #endregion
 

--- a/TargetSelector.cs
+++ b/TargetSelector.cs
@@ -445,7 +445,7 @@ namespace LeagueSharp.Common
     /// </summary>
     public class LockedTargetSelector
     {
-        private static Obj_AI_Hero _lastTarget;
+        public static Obj_AI_Hero _lastTarget;
         private static TargetSelector.DamageType _lastDamageType;
 
         public static Obj_AI_Hero GetTarget(float range,


### PR DESCRIPTION
added 'Shorten' as oppose to 'Extend', 

FiddleSticks' max rank Drain (w) have different buff name, hence most fiddlesticks' assemblies 'cancels' channeling W.
FiddleSticks' Crowstorm buff name only appears after finished channeling, Tested few interrupts on fiddlestick, only does after casting, as if it was gap closer.

made _lastTarget public so I could check before UnlockTarget 