### PR TITLE
More orbwalking fixes

### DIFF
--- a/Orbwalking.cs
+++ b/Orbwalking.cs
@@ -75,7 +75,8 @@ namespace LeagueSharp.Common
             "jarvanivcataclysmattack", "monkeykingdoubleattack",
             "shyvanadoubleattack", "shyvanadoubleattackdragon", "zyragraspingplantattack", "zyragraspingplantattack2",
             "zyragraspingplantattackfire", "zyragraspingplantattack2fire", "viktorpowertransfer", "sivirwattackbounce",
-            "elisespiderlingbasicattack"
+            "elisespiderlingbasicattack", "heimertyellowbasicattack", "heimertyellowbasicattack2", "heimertbluebasicattack",
+            "annietibbersbasicattack", "annietibbersbasicattack2"
         };
 
         //Spells that are attacks even if they dont have the "attack" word in their name.


### PR DESCRIPTION
Only thing left to check is Yorick ghouls I believe, I don't own him though.

Fixes orbwalking when:
- Annie has tibbers out
- Heimerdinger has basic and/or ult turret down