### PR TITLE
Even more orbwalker fixes

### DIFF
--- a/Orbwalking.cs
+++ b/Orbwalking.cs
@@ -76,7 +76,8 @@ namespace LeagueSharp.Common
             "shyvanadoubleattack", "shyvanadoubleattackdragon", "zyragraspingplantattack", "zyragraspingplantattack2",
             "zyragraspingplantattackfire", "zyragraspingplantattack2fire", "viktorpowertransfer", "sivirwattackbounce",
             "elisespiderlingbasicattack", "heimertyellowbasicattack", "heimertyellowbasicattack2", "heimertbluebasicattack",
-            "annietibbersbasicattack", "annietibbersbasicattack2"
+            "annietibbersbasicattack", "annietibbersbasicattack2", "yorickdecayedghoulbasicattack", "yorickravenousghoulbasicattack",
+            "yorickspectralghoulbasicattack", "malzaharvoidlingbasicattack", "malzaharvoidlingbasicattack2", "malzaharvoidlingbasicattack3"
         };
 
         //Spells that are attacks even if they dont have the "attack" word in their name.


### PR DESCRIPTION
Fixes orbwalking when:
- Yorick has ghouls out
- Malzahar has voidlings out

Still needs fixing:
- Yorick/Mordekaiser/Shaco clone/ghost attacks being considered as your own

(I'm not sure how to go about this while keeping it lightweight.)