### PR TITLE
Farm Delay Default Increased to 30

### DIFF
--- a/Orbwalking.cs
+++ b/Orbwalking.cs
@@ -892,7 +892,7 @@ namespace LeagueSharp.Common
                 /* Delay sliders */
                 _config.AddItem(
                     new MenuItem("ExtraWindup", "Extra windup time").SetShared().SetValue(new Slider(80, 0, 200)));
-                _config.AddItem(new MenuItem("FarmDelay", "Farm delay").SetShared().SetValue(new Slider(0, 0, 200)));
+                _config.AddItem(new MenuItem("FarmDelay", "Farm delay").SetShared().SetValue(new Slider(30, 0, 200)));
 
                 /*Load the menu*/
                 _config.AddItem(


### PR DESCRIPTION
Farm delay default value changed from 0 to 30 to temporarily fix some issues with last-hitting.